### PR TITLE
Fix: Ensure mobile Add Bookmark button visibility

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -184,7 +184,7 @@ export default function HomePage() {
           {isLoggedIn && (
             <Button
               size="icon"
-              className="md:hidden fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-20"
+              className="md:hidden fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-40"
               onClick={handleAddBookmark}
               aria-label="添加收藏"
             >


### PR DESCRIPTION
I increased the z-index of the mobile Floating Action Button (FAB) for "Add Bookmark" from z-20 to z-40. This change aims to prevent the button from being obscured by other positioned elements, while ensuring it remains below modal components (which typically use z-50).

Additionally, I removed a temporary diagnostic paragraph used to display the `isLoggedIn` state on mobile.

The visibility of the button is primarily controlled by the `isLoggedIn` state and the `md:hidden` Tailwind class, ensuring it appears only on mobile screens when you are logged in and no modal views are active.