### PR TITLE
feat: Add sidebar toggle button for PC mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
 import { Bookmark, Category } from '@/lib/types';
 import { MobileNavMenu } from '@/components/MobileNavMenu'; // For mobile category navigation
+import { SidebarToggleButton } from '@/components/SidebarToggleButton';
 
 // Mock Data
 const MOCK_CATEGORIES: Category[] = [
@@ -49,7 +50,12 @@ export default function HomePage() {
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>('all');
   const [displayedBookmarks, setDisplayedBookmarks] = useState<Bookmark[]>(MOCK_BOOKMARKS);
   const [currentCategoryName, setCurrentCategoryName] = useState<string>("所有收藏");
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
+
+  const toggleSidebar = () => {
+    setIsSidebarOpen(!isSidebarOpen);
+  };
 
   useEffect(() => {
     // Filter bookmarks based on activeCategoryId
@@ -132,19 +138,26 @@ export default function HomePage() {
         onLogout={handleLogout}
       />
       <div className="flex h-[calc(100vh-4rem)]"> {/* Adjust height for sticky nav */}
+        <SidebarToggleButton isSidebarOpen={isSidebarOpen} onClick={toggleSidebar} />
         {/* Desktop Sidebar */}
-        <div className="hidden md:flex">
-          <Sidebar
-            categories={categories}
-            activeCategoryId={activeCategoryId}
-            onSelectCategory={handleSelectCategory}
-            onToggleCategoryVisibility={handleToggleCategoryVisibility}
-            onAddCategory={handleAddCategory}
-            isLoggedIn={isLoggedIn}
-          />
-        </div>
+        {isSidebarOpen && (
+          <div className="hidden md:flex">
+            <Sidebar
+              categories={categories}
+              activeCategoryId={activeCategoryId}
+              onSelectCategory={handleSelectCategory}
+              onToggleCategoryVisibility={handleToggleCategoryVisibility}
+              onAddCategory={handleAddCategory}
+              isLoggedIn={isLoggedIn}
+            />
+          </div>
+        )}
 
-        <main className="flex-1 overflow-y-auto p-4 md:p-8 bg-slate-50 dark:bg-slate-900/50">
+        <main
+          className={`flex-1 overflow-y-auto p-4 md:p-8 bg-slate-50 dark:bg-slate-900/50 transition-all duration-300 ease-in-out ${
+            isSidebarOpen ? 'md:ml-64' : 'md:ml-16'
+          }`}
+        >
           {/* Mobile Header (inside main for scrolling) */}
           <header className="md:hidden flex items-center justify-between mb-6">
             <MobileNavMenu

--- a/src/components/SidebarToggleButton.tsx
+++ b/src/components/SidebarToggleButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { PanelLeftOpen, PanelLeftClose } from 'lucide-react';
+
+interface SidebarToggleButtonProps {
+  isSidebarOpen: boolean;
+  onClick: () => void;
+}
+
+export const SidebarToggleButton: React.FC<SidebarToggleButtonProps> = ({ isSidebarOpen, onClick }) => {
+  return (
+    <Button
+      onClick={onClick}
+      variant="outline"
+      size="icon"
+      className={`hidden md:inline-flex fixed top-16 z-50 transition-all duration-300 ease-in-out ${
+        isSidebarOpen ? 'left-[260px]' : 'left-2'
+      }`}
+      aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+    >
+      {isSidebarOpen ? <PanelLeftClose className="h-5 w-5" /> : <PanelLeftOpen className="h-5 w-5" />}
+    </Button>
+  );
+};


### PR DESCRIPTION
Implemented a toggle button to show and hide the sidebar in PC mode (md screens and above).

Key changes:
- Added `isSidebarOpen` state to `HomePage` to manage sidebar visibility.
- Created a `SidebarToggleButton` component that:
    - Displays `PanelLeftOpen` or `PanelLeftClose` icons based on the sidebar state.
    - Is fixed-positioned and remains partially visible (`left-2`) when the sidebar is closed, allowing it to be reopened.
    - Is positioned at `left-[260px]` when the sidebar is open.
    - Includes smooth transitions for position changes.
    - Is only visible on `md` screens and up.
- The `Sidebar` component in `HomePage` is now conditionally rendered based on `isSidebarOpen`.
- The main content area in `HomePage` adjusts its left margin (`md:ml-64` when open, `md:ml-16` when closed) with a smooth transition to accommodate the sidebar and the toggle button.
- Ensured accessibility with an `aria-label` for the icon-only toggle button.